### PR TITLE
Add support for multiple workspace folders

### DIFF
--- a/src/diff-mode.ts
+++ b/src/diff-mode.ts
@@ -418,7 +418,7 @@ class DiffMode {
 
     async getSourceDoc(hunk: Hunk | null): Promise<vscode.TextDocument | null> {
         const header = this.getHeader(hunk);
-        const repo = await RepositoryInfo.lookup();
+        const repo = await RepositoryInfo.getSelectedRepo();
         if (!header || !repo)
             return null;
         return workspace.openTextDocument(repo.getPathUri(header.toPath));

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ export async function updateIndex(
 }
 
 export async function uncommitFiles(files?: string[]) {
-    const repo = await RepositoryInfo.lookup();
+    const repo = await RepositoryInfo.getSelectedRepo();
     if (!repo)
         return;
     const index = await run('git', ['write-tree']);

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -8,6 +8,7 @@ import { run } from "./util";
 export class RepositoryInfo {
     private static repoCache =
         new Map<string, Promise<RepositoryInfo | null>>();
+    private static selectedRepo: Promise<RepositoryInfo | null> | null = null;
 
     private constructor(
         public readonly gitDir: string,
@@ -50,6 +51,10 @@ export class RepositoryInfo {
         return workspace.getWorkspaceFolder(activeEditor.document.uri);
     }
 
+    static async getSelectedRepo(): Promise<RepositoryInfo | null> {
+        return this.selectedRepo;
+    }
+
     static async lookup(): Promise<RepositoryInfo | null> {
         const ws_path = this.getActiveWorkspaceFolder()?.uri.path;
 
@@ -58,9 +63,12 @@ export class RepositoryInfo {
         }
 
         if (!this.repoCache.has(ws_path)) {
-            this.repoCache.set(ws_path, this.create(ws_path));
+            this.selectedRepo = this.create(ws_path);
+            this.repoCache.set(ws_path, this.selectedRepo);
+            return this.selectedRepo;
         }
 
-        return this.repoCache.get(ws_path)!;
+        this.selectedRepo = this.repoCache.get(ws_path)!;
+        return this.selectedRepo;
     }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -47,7 +47,8 @@ export async function runCommand(
     else
         throw new Error("Unexpected command");
 
-    const cwd = opts?.cwd ?? (await RepositoryInfo.lookup())?.topLevelDir;
+    const cwd = opts?.cwd
+        ?? (await RepositoryInfo.getSelectedRepo())?.topLevelDir;
     if (!cwd)
         return { stdout: "", stderr: "", ecode: -1 };
     const env = opts?.env ? { ...process.env, ...opts.env } : undefined;


### PR DESCRIPTION
If one has several workspace folders open, then the extension would open the first one in the list, regardless of what file you're editing. However, it makes more sense to open the one that you're currently working in, so you can use `stgit` in each of them.

This PR fixes that behavior by looking up the workspace folder for the "current editor" (or the most recent, if none is active IIUC). If no editor it open, it falls back to the previous default.

There is a similar problem that one can't open `vscode-stgit` for a submodule (which I haven't addressed).