### PR TITLE
Fix Typescript error

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
         "publish": "vsce publish"
     },
     "devDependencies": {
-        "@types/glob": "^7.2.0",
+        "@types/glob": "^8.0.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "16.x",
         "@types/vscode": "^1.78.0",


### PR DESCRIPTION
After installing with `npm install` and running `npm run compile` I got the following error:

```
> npm run compile


> stgit@0.9.9 compile
> tsc -p ./

node_modules/@types/glob/index.d.ts:29:42 - error TS2694: Namespace '".../vscode-stgit/node_modules/minimatch/dist/commonjs/index"' has no exported member 'IOptions'.

29     interface IOptions extends minimatch.IOptions {
                                            ~~~~~~~~

node_modules/@types/glob/index.d.ts:74:30 - error TS2724: '".../vscode-stgit/node_modules/minimatch/dist/commonjs/index"' has no exported member named 'IMinimatch'. Did you mean 'Minimatch'?

74         minimatch: minimatch.IMinimatch;
                                ~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/@types/glob/index.d.ts:29

 ERROR  npm failed with exit code 2
```

It turned out that the Typescript types didn't match the installed version of the package (`@types/glob` used `^7.2.0`, while `glob` used `^8.0.3`)