### PR TITLE
Make "create branch" a separate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,10 @@
             "category": "StGit",
             "title": "Mark Merge Conflict as Resolved"
         }, {
+            "command": "stgit.createBranch",
+            "category": "StGit",
+            "title": "Create Branch"
+        }, {
             "command": "stgit.switchBranch",
             "category": "StGit",
             "title": "Switch Branch"
@@ -318,6 +322,10 @@
         }, {
             "key": "shift+m",
             "command": "stgit.movePatchesTo",
+            "when": "resourceScheme == stgit && editorTextFocus && !commentEditorFocused"
+        }, {
+            "key": "ctrl+c shift+b",
+            "command": "stgit.createBranch",
             "when": "resourceScheme == stgit && editorTextFocus && !commentEditorFocused"
         }, {
             "key": "shift+b",

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -831,6 +831,14 @@ class StGitDoc {
         await run('stg', ['new', '-m', 'New patch']);
         this.reload();
     }
+    async createBranch() {
+        const branch = await window.showInputBox({
+            prompt: `Enter branch name`,
+        });
+        if (!branch)
+            return;
+        await runAndReportErrors('git', ['switch', '-c', branch]);
+    }
     async switchBranch() {
         if (this.index.deltas.length || this.workTree.deltas.length) {
             info("Work tree and index must be clean to switch branch");
@@ -846,12 +854,7 @@ class StGitDoc {
         if (!branch) {
             return;
         } else if (branch.includes('Create new branch')) {
-            const branch = await window.showInputBox({
-                prompt: `Enter branch name`,
-            });
-            if (!branch)
-                return;
-            await runAndReportErrors('git', ['switch', '-c', branch]);
+            this.createBranch();
         } else if (branch) {
             await runAndReportErrors('git', ['switch', branch]);
         }
@@ -1309,6 +1312,7 @@ class StGitMode {
             cmd('refresh', () => this.stgit?.refresh()),
             cmd('repair', () => this.stgit?.repair()),
             cmd('refreshSpecific', () => this.stgit?.refreshSpecific()),
+            cmd('createBranch', () => this.stgit?.createBranch()),
             cmd('switchBranch', () => this.stgit?.switchBranch()),
             cmd('rebase', () => this.stgit?.rebase()),
             cmd('gitFetch', () => this.stgit?.gitFetch()),

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -838,6 +838,8 @@ class StGitDoc {
         if (!branch)
             return;
         await runAndReportErrors('git', ['switch', '-c', branch]);
+        this.newUpstream = false;
+        this.reload();
     }
     async switchBranch() {
         if (this.index.deltas.length || this.workTree.deltas.length) {
@@ -857,9 +859,9 @@ class StGitDoc {
             this.createBranch();
         } else if (branch) {
             await runAndReportErrors('git', ['switch', branch]);
+            this.newUpstream = false;
+            this.reload();
         }
-        this.newUpstream = false;
-        this.reload();
     }
     private async allBranches() {
         const local = (await run('git', ['branch'])).split("\n");

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -837,7 +837,7 @@ class StGitDoc {
         });
         if (!branch)
             return;
-        await runAndReportErrors('git', ['switch', '-c', branch]);
+        await runAndReportErrors('stg', ['branch', '--create', branch]);
         this.newUpstream = false;
         this.reload();
     }


### PR DESCRIPTION
### Problem statement
Previously, one couldn't create a branch using the extension if one had **local modifications**. The "switch branch" dialogue was not available, since it requires a clean state. If you tried, you would get the following popup
![image](https://github.com/user-attachments/assets/d1932a4c-3716-41b2-bc38-3e876330bea7)

To work around it you would have to either:
- create the patch for the current branch, and then run "switch branch" -> "create branch",
- or run `stg branch -c` from the command line.

### Fix
- After this PR you can create a branch even if you have a dirty state, by using the new command "StGit: create branch". 
- I also gave it a shortcut: <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Shift</kbd>+<kbd>B</kbd> (similar to the shortcut for switching branches, <kbd>Shift</kbd>+<kbd>B</kbd>).