### PR TITLE
Fix: couldn't switch between workspaces properly

### DIFF
--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -1377,6 +1377,16 @@ class StGitMode {
     }
     private async openStgit() {
         if (this.stgit) {
+            const scheme = window.activeTextEditor?.document.uri.scheme || "";
+            const isInStgitBuffer = ['stgit', 'stgit-diff'].includes(scheme);
+            if (!isInStgitBuffer) {
+                const repo = await RepositoryInfo.lookup();
+                if (!repo) {
+                    info("Failed to find a GIT repository");
+                    return;
+                }
+                this.stgit.repo = repo;
+            }
             this.stgit.focusWindow();
             this.stgit.reload();
         } else {


### PR DESCRIPTION
This fixes a bug where the Stgit buffer wouldn't refresh with the current workspace's content. Instead it would keep showing the status for the repo that was used last.

I added a check so we skip the repo lookup if we're already in the Stgit buffer (so <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Ctrl</kbd>+<kbd>I</kbd> in that buffer essentially becomes equivalent to <kbd>G</kbd>).