### PR TITLE
Add support for navigating in/out of submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 -->
 
 ## 0.9.11 (unreleased)
+- Add support for navigating into/out of submodules with "Enter" and "-" keys.
+- Let the user switch branch when only submodules are changed.
 
 ## 0.9.10 (2025-07-12)
 - Improve switching between workspaces

--- a/package.json
+++ b/package.json
@@ -235,6 +235,10 @@
             "category": "StGit",
             "title": "Undo Recent Undo"
         }, {
+            "command": "stgit.navigateToParent",
+            "category": "StGit",
+            "title": "Navigate to Parent Repository (from submodule)"
+        }, {
             "command": "stgit.refresh",
             "category": "StGit",
             "title": "Append Changes to Current Patch"
@@ -410,6 +414,10 @@
         }, {
             "key": "enter",
             "command": "stgit.toggleExpand",
+            "when": "resourceScheme == stgit && editorTextFocus && !commentEditorFocused"
+        }, {
+            "key": "-",
+            "command": "stgit.navigateToParent",
             "when": "resourceScheme == stgit && editorTextFocus && !commentEditorFocused"
         }, {
             "key": "t",

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -56,7 +56,7 @@ export class RepositoryInfo {
      * Returns the stack and the relativePath for the given repo.
      */
     static async buildParentStack(repo: RepositoryInfo): Promise<{
-        stack: { repo: RepositoryInfo; relativePath: string }[];
+        stack: { repo: RepositoryInfo; relativePath: string; submodulePath: string }[];
         relativePath: string;
     }> {
         // Walk up to collect parent repos (nearest parent first)
@@ -84,13 +84,24 @@ export class RepositoryInfo {
             rootDir, repo.topLevelDir);
 
         // Build the stack from root to immediate parent
-        const stack: { repo: RepositoryInfo; relativePath: string }[] = [];
-        for (let i = parents.length - 1; i >= 0; i--) {
-            const p = parents[i];
+        // Each entry's submodulePath is the path from that repo
+        // to the next child repo down the chain
+        const chain = [...parents].reverse(); // [root, ..., immediate parent]
+        const stack: { repo: RepositoryInfo; relativePath: string; submodulePath: string }[] = [];
+        for (let i = 0; i < chain.length; i++) {
+            const child = (i + 1 < chain.length)
+                ? chain[i + 1] : repo;
+            const p = chain[i];
             const relPath = (p.topLevelDir === rootDir)
                 ? ''
                 : path.relative(rootDir, p.topLevelDir);
-            stack.push({ repo: p, relativePath: relPath });
+            const subPath = path.relative(
+                p.topLevelDir, child.topLevelDir);
+            stack.push({
+                repo: p,
+                relativePath: relPath,
+                submodulePath: subPath,
+            });
         }
         return { stack, relativePath };
     }

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -6,8 +6,6 @@ import { workspace } from 'vscode';
 import { run } from "./util";
 
 export class RepositoryInfo {
-    private static repoCache =
-        new Map<string, Promise<RepositoryInfo | null>>();
     private static selectedRepo: Promise<RepositoryInfo | null> | null = null;
 
     private constructor(
@@ -23,6 +21,12 @@ export class RepositoryInfo {
         return await run('git', ['rev-parse', '--show-toplevel'], {
             cwd: path,
         });
+    }
+
+    private static async findSuperprojectDir(path: string) {
+        return await run('git', [
+            'rev-parse', '--show-superproject-working-tree',
+        ], { cwd: path, inhibitLogging: true });
     }
 
     private static async findGitDir(path: string) {
@@ -41,34 +45,82 @@ export class RepositoryInfo {
         return null;
     }
 
-    private static getActiveWorkspaceFolder():
-        vscode.WorkspaceFolder | undefined {
-        const activeEditor = vscode.window.activeTextEditor;
-        if (!activeEditor) {
-            return workspace.workspaceFolders?.[0];
-        }
+    static async createForPath(path: string): Promise<RepositoryInfo | null> {
+        return this.create(path);
+    }
 
-        return workspace.getWorkspaceFolder(activeEditor.document.uri);
+    /**
+     * Build a parent stack for navigating out of submodules.
+     * Each entry has the parent repo and the relativePath that
+     * was active when that parent was the current repo.
+     * Returns the stack and the relativePath for the given repo.
+     */
+    static async buildParentStack(repo: RepositoryInfo): Promise<{
+        stack: { repo: RepositoryInfo; relativePath: string }[];
+        relativePath: string;
+    }> {
+        // Walk up to collect parent repos (nearest parent first)
+        const parents: RepositoryInfo[] = [];
+        let current = repo;
+        for (;;) {
+            const superDir = await this.findSuperprojectDir(
+                current.topLevelDir);
+            if (!superDir)
+                break;
+            const parent = await this.create(superDir);
+            if (!parent)
+                break;
+            parents.push(parent);
+            current = parent;
+        }
+        if (parents.length === 0)
+            return { stack: [], relativePath: '' };
+
+        // parents = [immediate parent, ..., root]
+        // root is parents[parents.length - 1]
+        const path = require('path');
+        const rootDir = parents[parents.length - 1].topLevelDir;
+        const relativePath = path.relative(
+            rootDir, repo.topLevelDir);
+
+        // Build the stack from root to immediate parent
+        const stack: { repo: RepositoryInfo; relativePath: string }[] = [];
+        for (let i = parents.length - 1; i >= 0; i--) {
+            const p = parents[i];
+            const relPath = (p.topLevelDir === rootDir)
+                ? ''
+                : path.relative(rootDir, p.topLevelDir);
+            stack.push({ repo: p, relativePath: relPath });
+        }
+        return { stack, relativePath };
     }
 
     static async getSelectedRepo(): Promise<RepositoryInfo | null> {
         return this.selectedRepo;
     }
 
+    static setSelectedRepo(repo: RepositoryInfo | null) {
+        this.selectedRepo = repo ? Promise.resolve(repo) : null;
+    }
+
     static async lookup(): Promise<RepositoryInfo | null> {
-        const ws_path = this.getActiveWorkspaceFolder()?.uri.path;
-
-        if (!ws_path) {
+        // Use the active file's directory so that files inside
+        // submodules resolve to the submodule's repo
+        const activeEditor = vscode.window.activeTextEditor;
+        let lookupPath: string | undefined;
+        if (activeEditor &&
+            activeEditor.document.uri.scheme === 'file') {
+            const path = require('path');
+            lookupPath = path.dirname(
+                activeEditor.document.uri.fsPath);
+        }
+        if (!lookupPath) {
+            lookupPath = workspace.workspaceFolders?.[0]?.uri.path;
+        }
+        if (!lookupPath)
             return null;
-        }
 
-        if (!this.repoCache.has(ws_path)) {
-            this.selectedRepo = this.create(ws_path);
-            this.repoCache.set(ws_path, this.selectedRepo);
-            return this.selectedRepo;
-        }
-
-        this.selectedRepo = this.repoCache.get(ws_path)!;
+        this.selectedRepo = this.create(lookupPath);
         return this.selectedRepo;
     }
 }

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -330,7 +330,11 @@ class StGitDoc {
 
     // Submodule navigation context
     // Stack of parent repos with their relative paths for navigation
-    private parentRepoStack: { repo: RepositoryInfo; relativePath: string }[] = [];
+    private parentRepoStack: {
+        repo: RepositoryInfo;
+        relativePath: string;
+        submodulePath: string;
+    }[] = [];
     private relativePathFromRoot = '';
 
     // start of history
@@ -1061,6 +1065,7 @@ class StGitDoc {
         this.parentRepoStack.push({
             repo: this.repo,
             relativePath: this.relativePathFromRoot,
+            submodulePath: submodulePath,
         });
 
         // Update the relative path from root
@@ -1093,7 +1098,7 @@ class StGitDoc {
         this.repo = parent.repo;
         RepositoryInfo.setSelectedRepo(parent.repo);
         this.reload();
-        this.moveCursorToIndex();
+        this.moveCursorToDelta(parent.submodulePath);
     }
     async resolveConflict() {
         const change = this.curChange;
@@ -1248,6 +1253,39 @@ class StGitDoc {
         if (!editor)
             return;
         this.moveCursorToIndexAtOpen(editor);
+    }
+
+    private moveCursorToDelta(path: string) {
+        const editor = this.editor;
+        if (!editor)
+            return;
+        let done = false;
+        // The work tree deltas may load after several document
+        // updates, so keep trying on each update until found.
+        const watcher = workspace.onDidChangeTextDocument((e) => {
+            if (e.document !== this.doc || done)
+                return;
+            for (const p of this.patches) {
+                const idx = p.deltas.findIndex(
+                    d => d.path === path);
+                if (idx >= 0) {
+                    const line = p.lineNum + idx + 1;
+                    const pos = new vscode.Position(line, 0);
+                    editor.selection =
+                        new vscode.Selection(pos, pos);
+                    editor.revealRange(
+                        new vscode.Range(pos, pos));
+                    done = true;
+                    return;
+                }
+            }
+        });
+        sleep(4000).then(() => {
+            watcher.dispose();
+            // Fall back to index if delta was never found
+            if (!done)
+                this.moveCursorToIndex();
+        });
     }
 
     private async moveCursorToIndexAtOpen(editor: vscode.TextEditor) {

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -55,6 +55,9 @@ class Delta {
     get conflict() {
         return this.status.startsWith('U');
     }
+    get isSubmodule() {
+        return this.srcMode === '160000' || this.destMode === '160000';
+    }
     private get stageInfoString() {
         if (!this.indexStageInfo.length)
             return "";
@@ -82,9 +85,10 @@ class Delta {
         const what = Delta.STATUS_MESSAGE[this.status];
         const s = `${what}${this.permissionDelta}`;
         const dest = this.destPath ? ` -> ${this.destPath}` : '';
-        const s2 = `    ${s.padEnd(16)} ${this.path}${dest}`;
+        const submoduleMarker = this.isSubmodule ? ' [submodule]' : '';
+        const s2 = `    ${s.padEnd(16)} ${this.path}${dest}${submoduleMarker}`;
         const sinfo = this.stageInfoString;
-        if (!sinfo && !dest)
+        if (!sinfo && !dest && !submoduleMarker)
             return s2;
         return `${s2.padEnd(50)} ${sinfo}`;
     }
@@ -324,6 +328,11 @@ class StGitDoc {
     private remoteBranch: string | null = null;
     private newUpstream = false;
 
+    // Submodule navigation context
+    // Stack of parent repos with their relative paths for navigation
+    private parentRepoStack: { repo: RepositoryInfo; relativePath: string }[] = [];
+    private relativePathFromRoot = '';
+
     // start of history
     private baseSha: string | null = null;
 
@@ -338,6 +347,7 @@ class StGitDoc {
 
     private highlightRanges: vscode.Range[] = [];
     private historyRanges: vscode.Range[] = [];
+    private submoduleRanges: vscode.Range[] = [];
 
     constructor(
         public doc: vscode.TextDocument,
@@ -369,6 +379,7 @@ class StGitDoc {
             })
         );
         this.updateConfiguration({ reload: false });
+        this.setupSubmoduleContext(repo);
         this.reload();
         this.openInitialEditor();
     }
@@ -390,6 +401,13 @@ class StGitDoc {
         this.unknownFilesVisible = config.showUnknownFiles;
         if (opt.reload)
             this.reload();
+    }
+
+    async setupSubmoduleContext(repo: RepositoryInfo) {
+        const { stack, relativePath } =
+            await RepositoryInfo.buildParentStack(repo);
+        this.parentRepoStack = stack;
+        this.relativePathFromRoot = relativePath;
     }
 
     async reloadIndex() {
@@ -842,7 +860,10 @@ class StGitDoc {
         this.reload();
     }
     async switchBranch() {
-        if (this.index.deltas.length || this.workTree.deltas.length) {
+        const indexDeltas = this.index.deltas.filter(d => !d.isSubmodule);
+        const workTreeDeltas = this.workTree.deltas.filter(
+            d => !d.isSubmodule);
+        if (indexDeltas.length || workTreeDeltas.length) {
             info("Work tree and index must be clean to switch branch");
             return;
         }
@@ -999,6 +1020,11 @@ class StGitDoc {
         const patch = this.curPatch;
         const delta = this.curChange;
         if (delta) {
+            // Check if the delta is a submodule - if so, navigate into it
+            if (delta.isSubmodule) {
+                await this.navigateToSubmodule(delta.path);
+                return;
+            }
             const uri = this.repo.getPathUri(delta.path);
             if (!uri)
                 return;
@@ -1019,6 +1045,55 @@ class StGitDoc {
                     this.initializeBranch();
             }
         }
+    }
+    async navigateToSubmodule(submodulePath: string) {
+        // Construct the full path to the submodule
+        const fullPath = this.repo.getPathUri(submodulePath).fsPath;
+
+        // Create a new RepositoryInfo for the submodule
+        const submoduleRepo = await RepositoryInfo.createForPath(fullPath);
+        if (!submoduleRepo) {
+            info(`Failed to open submodule at ${submodulePath}`);
+            return;
+        }
+
+        // Push current repo and relative path onto the parent stack
+        this.parentRepoStack.push({
+            repo: this.repo,
+            relativePath: this.relativePathFromRoot,
+        });
+
+        // Update the relative path from root
+        if (this.relativePathFromRoot) {
+            this.relativePathFromRoot =
+                `${this.relativePathFromRoot}/${submodulePath}`;
+        } else {
+            this.relativePathFromRoot = submodulePath;
+        }
+
+        // Switch to the submodule repo and update the selected repo
+        this.repo = submoduleRepo;
+        RepositoryInfo.setSelectedRepo(submoduleRepo);
+        this.reload();
+        this.moveCursorToIndex();
+    }
+    async navigateToParent() {
+        if (this.parentRepoStack.length === 0) {
+            info("Already at root repository");
+            return;
+        }
+
+        // Pop the parent repo and relative path from the stack
+        const parent = this.parentRepoStack.pop()!;
+
+        // Restore the relative path from the stack
+        this.relativePathFromRoot = parent.relativePath;
+
+        // Switch to the parent repo and update the selected repo
+        this.repo = parent.repo;
+        RepositoryInfo.setSelectedRepo(parent.repo);
+        this.reload();
+        this.moveCursorToIndex();
     }
     async resolveConflict() {
         const change = this.curChange;
@@ -1168,6 +1243,13 @@ class StGitDoc {
         this.moveCursorToIndexAtOpen(editor);
     }
 
+    private async moveCursorToIndex() {
+        const editor = this.editor;
+        if (!editor)
+            return;
+        this.moveCursorToIndexAtOpen(editor);
+    }
+
     private async moveCursorToIndexAtOpen(editor: vscode.TextEditor) {
         let done = false;
         const watcher = workspace.onDidChangeTextDocument((e) => {
@@ -1192,6 +1274,10 @@ class StGitDoc {
                 p => new vscode.Range(p.lineNum, 2, p.lineNum, 2));
         this.historyRanges = this.history.map(
             p => new vscode.Range(p.lineNum, 0, p.lineNum, 999));
+        // Submodule line is line 0 when inside a submodule
+        this.submoduleRanges = this.relativePathFromRoot
+            ? [new vscode.Range(0, 0, 0, 999)]
+            : [];
         this.updateEditorDecorations();
     }
 
@@ -1205,6 +1291,8 @@ class StGitDoc {
                 cls.fileHighlightDecoration, this.highlightRanges);
             editor.setDecorations(
                 cls.historyDecoration, this.historyRanges);
+            editor.setDecorations(
+                cls.submoduleDecoration, this.submoduleRanges);
         }
     }
 
@@ -1251,7 +1339,12 @@ class StGitDoc {
 
     get documentContents(): string {
         const b = this.branchName ?? this.baseSha?.slice(0, 16) ?? "<unknown>";
-        const lines = [`Branch: ${b}${this.upstreamString}`, ""];
+        const branchLine = `Branch: ${b}${this.upstreamString}`;
+        const lines: string[] = [];
+        if (this.relativePathFromRoot) {
+            lines.push(`Submodule: ${this.relativePathFromRoot}`);
+        }
+        lines.push(branchLine, "");
         function pushVec(patches: Patch[]) {
             for (const p of patches) {
                 const patchLines = p.getLines();
@@ -1293,6 +1386,11 @@ class StGitMode {
     readonly historyDecoration = window.createTextEditorDecorationType({
         dark: { color: "#777", },
         light: { color: "#999", },
+    });
+    readonly submoduleDecoration = window.createTextEditorDecorationType({
+        dark: { color: "#4EC9B0", },  // Teal/cyan color
+        light: { color: "#16825D", }, // Darker green for light themes
+        fontStyle: "italic",
     });
     constructor(context: vscode.ExtensionContext) {
         const provider: vscode.TextDocumentContentProvider = {
@@ -1357,6 +1455,7 @@ class StGitMode {
             cmd('hardUndo', () => this.stgit?.hardUndo()),
             cmd('redo', () => this.stgit?.redo()),
             cmd('help', () => this.stgit?.help()),
+            cmd('navigateToParent', () => this.stgit?.navigateToParent()),
 
             workspace.registerTextDocumentContentProvider('stgit', provider),
 
@@ -1380,6 +1479,7 @@ class StGitMode {
 
         this.fileHighlightDecoration.dispose();
         this.historyDecoration.dispose();
+        this.submoduleDecoration.dispose();
     }
     private async openStgit() {
         if (this.stgit) {
@@ -1392,6 +1492,8 @@ class StGitMode {
                     return;
                 }
                 this.stgit.repo = repo;
+                RepositoryInfo.setSelectedRepo(repo);
+                await this.stgit.setupSubmoduleContext(repo);
             }
             this.stgit.focusWindow();
             this.stgit.reload();
@@ -1401,6 +1503,7 @@ class StGitMode {
                 info("Failed to find a GIT repository");
                 return;
             }
+            RepositoryInfo.setSelectedRepo(repo);
             const doc = await workspace.openTextDocument(this.uri);
             this.stgit = new StGitDoc(doc, repo,
                 () => this.changeEmitter.fire(doc.uri),

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -1098,7 +1098,7 @@ class StGitDoc {
         this.repo = parent.repo;
         RepositoryInfo.setSelectedRepo(parent.repo);
         this.reload();
-        this.moveCursorToDelta(parent.submodulePath);
+        await this.moveCursorToDelta(parent.submodulePath);
     }
     async resolveConflict() {
         const change = this.curChange;
@@ -1255,55 +1255,64 @@ class StGitDoc {
         this.moveCursorToIndexAtOpen(editor);
     }
 
-    private moveCursorToDelta(path: string) {
+    private async moveCursorToDelta(path: string) {
         const editor = this.editor;
         if (!editor)
             return;
-        let done = false;
         // The work tree deltas may load after several document
         // updates, so keep trying on each update until found.
+        let resolve: () => void;
+        const found = new Promise<void>(r => { resolve = r; });
         const watcher = workspace.onDidChangeTextDocument((e) => {
-            if (e.document !== this.doc || done)
+            if (e.document !== this.doc)
                 return;
             for (const p of this.patches) {
                 const idx = p.deltas.findIndex(
                     d => d.path === path);
-                if (idx >= 0) {
-                    const line = p.lineNum + idx + 1;
-                    const pos = new vscode.Position(line, 0);
-                    editor.selection =
-                        new vscode.Selection(pos, pos);
-                    editor.revealRange(
-                        new vscode.Range(pos, pos));
-                    done = true;
-                    return;
+                if (idx < 0) {
+                    continue;
                 }
+                const line = p.lineNum + idx + 1;
+                const pos = new vscode.Position(line, 0);
+                editor.selection =
+                    new vscode.Selection(pos, pos);
+                editor.revealRange(
+                    new vscode.Range(pos, pos));
+                resolve();
+                return;
             }
         });
-        sleep(4000).then(() => {
-            watcher.dispose();
-            // Fall back to index if delta was never found
-            if (!done)
-                this.moveCursorToIndex();
-        });
+        const winner = await Promise.race([
+            found.then(() => 'found' as const),
+            sleep(4000).then(() => 'timeout' as const),
+        ]);
+        watcher.dispose();
+        if (winner === 'timeout')
+            this.moveCursorToIndex();
     }
 
     private async moveCursorToIndexAtOpen(editor: vscode.TextEditor) {
-        let done = false;
+        let resolve: () => void;
+        const found = new Promise<void>(r => { resolve = r; });
         const watcher = workspace.onDidChangeTextDocument((e) => {
-            if (e.document !== this.doc || done)
+            if (e.document !== this.doc)
                 return;
             const line = this.index.lineNum;
-            if (line !== 0) {
-                const p = new vscode.Position(line, 0);
-                editor.selection = new vscode.Selection(p, p);
-                editor.revealRange(new vscode.Range(p, p));
-                done = true;
+            if (line === 0) {
                 return;
             }
+            const p = new vscode.Position(line, 0);
+            editor.selection = new vscode.Selection(p, p);
+            editor.revealRange(new vscode.Range(p, p));
+            resolve();
         });
-        await sleep(4000);
+        const winner = await Promise.race([
+            found.then(() => 'found' as const),
+            sleep(4000).then(() => 'timeout' as const),
+        ]);
         watcher.dispose();
+        if (winner === 'timeout')
+            this.moveCursorToIndex();
     }
 
     private updateDecorations() {

--- a/src/stgit.ts
+++ b/src/stgit.ts
@@ -1316,6 +1316,22 @@ class StGitDoc {
         this.submoduleRanges = this.relativePathFromRoot
             ? [new vscode.Range(0, 0, 0, 999)]
             : [];
+        // Also highlight [submodule] suffix on delta lines
+        for (const p of this.patches) {
+            if (p.lineCount <= 1)
+                continue;
+            for (let i = 0; i < p.deltas.length; i++) {
+                const d = p.deltas[i];
+                if (!d.isSubmodule)
+                    continue;
+                const line = p.lineNum + i + 1;
+                const col = d.docLine.indexOf('[submodule]');
+                if (col >= 0) {
+                    this.submoduleRanges.push(new vscode.Range(
+                        line, col, line, col + '[submodule]'.length));
+                }
+            }
+        }
         this.updateEditorDecorations();
     }
 


### PR DESCRIPTION
Implements the feature mentioned in https://github.com/srydh/vscode-stgit/discussions/6

Demo showing me opening a submodule "stgit" and then going back to the parent repo (with -)

https://github.com/user-attachments/assets/12a528d7-4b02-45e5-9ef5-b422911e7a27

